### PR TITLE
Remove needs cxx11

### DIFF
--- a/Formula/valet-php@5.6.rb
+++ b/Formula/valet-php@5.6.rb
@@ -43,8 +43,6 @@ class ValetPhpAT56 < Formula
   # see https://github.com/php/php-src/pull/3472
   patch :DATA
 
-  needs :cxx11
-
   def install
     # Ensure that libxml2 will be detected correctly in older MacOS
     if MacOS.version == :el_capitan || MacOS.version == :sierra
@@ -81,9 +79,6 @@ class ValetPhpAT56 < Formula
 
     # API compatibility with tidy-html5 v5.0.0 - https://github.com/htacg/tidy-html5/issues/224
     inreplace "ext/tidy/tidy.c", "buffio.h", "tidybuffio.h"
-
-    # Required due to icu4c dependency
-    ENV.cxx11
 
     # icu4c 61.1 compatability
     ENV.append "CPPFLAGS", "-DU_USING_ICU_NAMESPACE=1"

--- a/Formula/valet-php@7.0.rb
+++ b/Formula/valet-php@7.0.rb
@@ -45,8 +45,6 @@ class ValetPhpAT70 < Formula
   # see https://github.com/php/php-src/pull/3472
   patch :DATA
 
-  needs :cxx11
-
   def install
     # Ensure that libxml2 will be detected correctly in older MacOS
     if MacOS.version == :el_capitan || MacOS.version == :sierra
@@ -83,9 +81,6 @@ class ValetPhpAT70 < Formula
 
     # API compatibility with tidy-html5 v5.0.0 - https://github.com/htacg/tidy-html5/issues/224
     inreplace "ext/tidy/tidy.c", "buffio.h", "tidybuffio.h"
-
-    # Required due to icu4c dependency
-    ENV.cxx11
 
     # icu4c 61.1 compatability
     ENV.append "CPPFLAGS", "-DU_USING_ICU_NAMESPACE=1"

--- a/Formula/valet-php@7.1.rb
+++ b/Formula/valet-php@7.1.rb
@@ -44,8 +44,6 @@ class ValetPhpAT71 < Formula
   # see https://github.com/php/php-src/pull/3472
   patch :DATA
 
-  needs :cxx11
-
   def install
     # Ensure that libxml2 will be detected correctly in older MacOS
     if MacOS.version == :el_capitan || MacOS.version == :sierra
@@ -79,9 +77,6 @@ class ValetPhpAT71 < Formula
               "your httpd config to use the prefork MPM"
 
     inreplace "sapi/fpm/php-fpm.conf.in", ";daemonize = yes", "daemonize = no"
-
-    # Required due to icu4c dependency
-    ENV.cxx11
 
     config_path = etc/"valet-php/#{php_version}"
     # Prevent system pear config from inhibiting pear install

--- a/Formula/valet-php@7.2.rb
+++ b/Formula/valet-php@7.2.rb
@@ -45,8 +45,6 @@ class ValetPhpAT72 < Formula
   # see https://github.com/php/php-src/pull/3472
   patch :DATA
 
-  needs :cxx11
-
   def install
     # Ensure that libxml2 will be detected correctly in older MacOS
     if MacOS.version == :el_capitan || MacOS.version == :sierra
@@ -81,9 +79,6 @@ class ValetPhpAT72 < Formula
               "your httpd config to use the prefork MPM"
 
     inreplace "sapi/fpm/php-fpm.conf.in", ";daemonize = yes", "daemonize = no"
-
-    # Required due to icu4c dependency
-    ENV.cxx11
 
     config_path = etc/"valet-php/#{php_version}"
     # Prevent system pear config from inhibiting pear install

--- a/Formula/valet-php@7.3.rb
+++ b/Formula/valet-php@7.3.rb
@@ -44,8 +44,6 @@ class ValetPhpAT73 < Formula
   # see https://github.com/php/php-src/pull/3472
   patch :DATA
 
-  needs :cxx11
-
   def install
     # Ensure that libxml2 will be detected correctly in older MacOS
     if MacOS.version == :el_capitan || MacOS.version == :sierra
@@ -80,9 +78,6 @@ class ValetPhpAT73 < Formula
               "your httpd config to use the prefork MPM"
 
     inreplace "sapi/fpm/php-fpm.conf.in", ";daemonize = yes", "daemonize = no"
-
-    # Required due to icu4c dependency
-    ENV.cxx11
 
     config_path = etc/"valet-php/#{php_version}"
     # Prevent system pear config from inhibiting pear install


### PR DESCRIPTION
#1 It looks like "needs cxx11" isn't a supported option anymore and hasn't
been needed for some time now. Currently the option breaks the formula.