### PR TITLE
Update valet-php@7.2.rb

### DIFF
--- a/Formula/valet-php@7.2.rb
+++ b/Formula/valet-php@7.2.rb
@@ -51,7 +51,8 @@ class ValetPhpAT72 < Formula
 
     # Work around configure issues with Xcode 12
     # See https://bugs.php.net/bug.php?id=80171
-    ENV.append "CFLAGS", "-Wno-implicit-function-declaration"
+    ENV.append "CFLAGS", "-Wno-implicit-function-declaration -DU_DEFINE_FALSE_AND_TRUE=1"
+    ENV.append "CXXFLAGS", "-DU_DEFINE_FALSE_AND_TRUE=1"
 
     # buildconf required due to system library linking bug patch
     system "./buildconf", "--force"


### PR DESCRIPTION
Will fix compilation error in intl-module while make

/private/tmp/valet-php-7.2-20210228-18183-1ctjjm0/php-7.2.34/ext/intl/collator/collator_sort.c:349:26: error: use of undeclared identifier 'TRUE'
        collator_sort_internal( TRUE, INTERNAL_FUNCTION_PARAM_PASSTHRU );
                                ^
/private/tmp/valet-php-7.2-20210228-18183-1ctjjm0/php-7.2.34/ext/intl/collator/collator_sort.c:543:26: error: use of undeclared identifier 'FALSE'
        collator_sort_internal( FALSE, INTERNAL_FUNCTION_PARAM_PASSTHRU );