### PR TITLE
Change Php 7.4 formula's argument: "--with-external-gd" to "--with-gd" to prevent errors during install

### DIFF
--- a/Formula/valet-php@7.4.rb
+++ b/Formula/valet-php@7.4.rb
@@ -130,7 +130,7 @@ class ValetPhpAT74 < Formula
       --with-apxs2=#{Formula["httpd"].opt_bin}/apxs
       --with-bz2#{headers_path}
       --with-curl
-      --with-external-gd
+      --with-gd
       --with-external-pcre
       --with-ffi
       --with-fpm-user=_www


### PR DESCRIPTION
In issue https://github.com/henkrehorst/homebrew-php/issues/151 a build from source failed due to Make script referencing Php GD constants. These constants were not defined due to the formula relying on an external GD installation.