### PR TITLE
Fix compilation of PHP due ICU 70

### DIFF
--- a/Formula/valet-php@7.0.rb
+++ b/Formula/valet-php@7.0.rb
@@ -43,6 +43,13 @@ class ValetPhpAT70 < Formula
   # PHP build system incorrectly links system libraries
   # see https://github.com/php/php-src/pull/3472
   patch :DATA
+  
+   # PHP build system ICU70 fails
+   # see https://github.com/php/php-src/pull/7596
+  patch :p0 do
+    url "https://raw.githubusercontent.com/henkrehorst/homebrew-php/master/Patches/php70-icu70.patch"
+    sha256 "f87421fc2d9e0a68eb9b9b280b9ba86ed45927f918f74f73593e08920cf17377"
+  end
 
   def install
     # Ensure that libxml2 will be detected correctly in older MacOS

--- a/Formula/valet-php@7.1.rb
+++ b/Formula/valet-php@7.1.rb
@@ -42,7 +42,13 @@ class ValetPhpAT71 < Formula
   # PHP build system incorrectly links system libraries
   # see https://github.com/php/php-src/pull/3472
   patch :DATA
-
+  
+  # PHP build system ICU70 fails
+  # see https://github.com/php/php-src/pull/7596
+  patch do
+    url "https://raw.githubusercontent.com/henkrehorst/homebrew-php/master/Patches/php71-icu70.patch"
+    sha256 "04c1659bce7acbb9ee65d9f960ea867120c81c82668603e1a71095dd58ce5a46"
+  end
   def install
     # Ensure that libxml2 will be detected correctly in older MacOS
     ENV["SDKROOT"] = MacOS.sdk_path if MacOS.version == :el_capitan || MacOS.version == :sierra

--- a/Formula/valet-php@7.2.rb
+++ b/Formula/valet-php@7.2.rb
@@ -43,6 +43,13 @@ class ValetPhpAT72 < Formula
   # PHP build system incorrectly links system libraries
   # see https://github.com/php/php-src/pull/3472
   patch :DATA
+  
+  # PHP build system ICU70 fails
+  # see https://github.com/php/php-src/pull/7596
+  patch do
+    url "https://raw.githubusercontent.com/henkrehorst/homebrew-php/master/Patches/php71-icu70.patch"
+    sha256 "9f604be7b5021f5f840229392b1ca4c8db35f48f5f1a4085b533bf97985cfd5f"
+  end
 
   def install
     # Ensure that libxml2 will be detected correctly in older MacOS

--- a/Formula/valet-php@7.3.rb
+++ b/Formula/valet-php@7.3.rb
@@ -43,7 +43,14 @@ class ValetPhpAT73 < Formula
   # PHP build system incorrectly links system libraries
   # see https://github.com/php/php-src/pull/3472
   patch :DATA
-
+  
+  # PHP build system ICU70 fails
+  # see https://github.com/php/php-src/pull/7596
+  patch do
+    url "https://raw.githubusercontent.com/henkrehorst/homebrew-php/master/Patches/php73-icu70.patch"
+    sha256 "c6e76b4afd97f15b85c4bb894c5e97631924d002cd2538b0693437f5e38446cf"
+  end
+  
   def install
     # Ensure that libxml2 will be detected correctly in older MacOS
     ENV["SDKROOT"] = MacOS.sdk_path if MacOS.version == :el_capitan || MacOS.version == :sierra

--- a/Formula/valet-php@7.4.rb
+++ b/Formula/valet-php@7.4.rb
@@ -1,8 +1,8 @@
 class ValetPhpAT74 < Formula
   desc "General-purpose scripting language"
   homepage "https://www.php.net/"
-  url "https://www.php.net/distributions/php-7.4.16.tar.xz"
-  sha256 "1c16cefaf88ded4c92eed6a8a41eb682bb2ef42429deb55f1c4ba159053fb98b"
+  url "https://www.php.net/distributions/php-7.4.28.tar.xz" 
+  sha256 "9cc3b6f6217b60582f78566b3814532c4b71d517876c25013ae51811e65d8fce"
 
   bottle do
     root_url "https://dl.bintray.com/henkrehorst/valet-php"

--- a/Formula/valet-php@8.0.rb
+++ b/Formula/valet-php@8.0.rb
@@ -1,8 +1,8 @@
 class ValetPhpAT80 < Formula
   desc "General-purpose scripting language"
   homepage "https://www.php.net/"
-  url "https://www.php.net/distributions/php-8.0.3.tar.xz"
-  sha256 "c9816aa9745a9695672951eaff3a35ca5eddcb9cacf87a4f04b9fb1169010251"
+  url "https://www.php.net/distributions/php-8.0.17.tar.xz"
+  sha256 "4e7d94bb3d144412cb8b2adeb599fb1c6c1d7b357b0d0d0478dc5ef53532ebc5"
 
   bottle do
     root_url "https://dl.bintray.com/henkrehorst/valet-php"

--- a/Formula/valet-php@8.1.rb
+++ b/Formula/valet-php@8.1.rb
@@ -1,8 +1,8 @@
 class ValetPhpAT81 < Formula
   desc "General-purpose scripting language"
   homepage "https://www.php.net/"
-  url "https://www.php.net/distributions/php-8.1.2.tar.xz"
-  sha256 "6b448242fd360c1a9f265b7263abf3da25d28f2b2b0f5465533b69be51a391dd"
+  url "https://www.php.net/distributions/php-8.1.4.tar.xz"
+  sha256 "05a8c0ac30008154fb38a305560543fc172ba79fb957084a99b8d3b10d5bdb4b"
 
   bottle do
     root_url "https://dl.bintray.com/henkrehorst/valet-php"

--- a/Patches/php70-icu70.patch
+++ b/Patches/php70-icu70.patch
@@ -1,0 +1,85 @@
+--- ext/intl/breakiterator/codepointiterator_internal.cpp
++++ ext/intl/breakiterator/codepointiterator_internal.cpp
+@@ -67,21 +67,25 @@
+ }
+
+ CodePointBreakIterator::~CodePointBreakIterator()
+ {
+ 	if (this->fText) {
+ 		utext_close(this->fText);
+ 	}
+ 	clearCurrentCharIter();
+ }
+
+-UBool CodePointBreakIterator::operator==(const BreakIterator& that) const
++#if U_ICU_VERSION_MAJOR_NUM >= 70
++ bool CodePointBreakIterator::operator==(const BreakIterator& that) const
++#else
++ UBool CodePointBreakIterator::operator==(const BreakIterator& that) const
++#endif
+ {
+ 	if (typeid(*this) != typeid(that)) {
+ 		return FALSE;
+ 	}
+
+ 	const CodePointBreakIterator& that2 =
+ 		static_cast<const CodePointBreakIterator&>(that);
+
+ 	if (!utext_equals(this->fText, that2.fText)) {
+ 		return FALSE;
+--- ext/intl/breakiterator/codepointiterator_internal.h
++++ ext/intl/breakiterator/codepointiterator_internal.h
+@@ -29,21 +29,25 @@
+ 		static UClassID getStaticClassID();
+
+ 		CodePointBreakIterator();
+
+ 		CodePointBreakIterator(const CodePointBreakIterator &other);
+
+ 		CodePointBreakIterator& operator=(const CodePointBreakIterator& that);
+
+ 		virtual ~CodePointBreakIterator();
+
++#if U_ICU_VERSION_MAJOR_NUM >= 70
++		virtual bool operator==(const BreakIterator& that) const;
++#else
+ 		virtual UBool operator==(const BreakIterator& that) const;
++#endif
+
+ 		virtual CodePointBreakIterator* clone(void) const;
+
+ 		virtual UClassID getDynamicClassID(void) const;
+
+ 		virtual CharacterIterator& getText(void) const;
+
+ 		virtual UText *getUText(UText *fillIn, UErrorCode &status) const;
+
+ 		virtual void setText(const UnicodeString &text);
+--- ext/intl/locale/locale_methods.c
++++ ext/intl/locale/locale_methods.c
+@@ -1335,11 +1335,11 @@
+ 		token 	= strstr( cur_lang_tag , cur_loc_range );
+
+ 		if( token && (token==cur_lang_tag) ){
+ 			/* check if the char. after match is SEPARATOR */
+ 			chrcheck = token + (strlen(cur_loc_range));
+-			if( isIDSeparator(*chrcheck) || isEndOfTag(*chrcheck) ){
++			if( isIDSeparator(*chrcheck) || isKeywordSeparator(*chrcheck) || isEndOfTag(*chrcheck) ){
+ 				if( cur_lang_tag){
+ 					efree( cur_lang_tag );
+ 				}
+ 				if( cur_loc_range){
+ 					efree( cur_loc_range );
+@@ -1391,11 +1391,11 @@
+ 		token 	= strstr( cur_lang_tag , cur_loc_range );
+
+ 		if( token && (token==cur_lang_tag) ){
+ 			/* check if the char. after match is SEPARATOR */
+ 			chrcheck = token + (strlen(cur_loc_range));
+-			if( isIDSeparator(*chrcheck) || isEndOfTag(*chrcheck) ){
++			if( isIDSeparator(*chrcheck) || isKeywordSeparator(*chrcheck) || isEndOfTag(*chrcheck) ){
+ 				if( cur_lang_tag){
+ 					efree( cur_lang_tag );
+ 				}
+ 				if( cur_loc_range){
+ 					efree( cur_loc_range );

--- a/Patches/php71-icu70.patch
+++ b/Patches/php71-icu70.patch
@@ -1,0 +1,57 @@
+--- /ext/intl/breakiterator/codepointiterator_internal.cpp
++++ /ext/intl/breakiterator/codepointiterator_internal.cpp
+@@ -67,21 +67,25 @@
+ }
+
+ CodePointBreakIterator::~CodePointBreakIterator()
+ {
+ 	if (this->fText) {
+ 		utext_close(this->fText);
+ 	}
+ 	clearCurrentCharIter();
+ }
+
+-UBool CodePointBreakIterator::operator==(const BreakIterator& that) const
++#if U_ICU_VERSION_MAJOR_NUM >= 70
++ bool CodePointBreakIterator::operator==(const BreakIterator& that) const
++#else
++ UBool CodePointBreakIterator::operator==(const BreakIterator& that) const
++#endif
+ {
+ 	if (typeid(*this) != typeid(that)) {
+ 		return FALSE;
+ 	}
+
+ 	const CodePointBreakIterator& that2 =
+ 		static_cast<const CodePointBreakIterator&>(that);
+
+ 	if (!utext_equals(this->fText, that2.fText)) {
+ 		return FALSE;
+--- /ext/intl/breakiterator/codepointiterator_internal.h
++++ /ext/intl/breakiterator/codepointiterator_internal.h
+@@ -29,21 +29,25 @@
+ 		static UClassID getStaticClassID();
+
+ 		CodePointBreakIterator();
+
+ 		CodePointBreakIterator(const CodePointBreakIterator &other);
+
+ 		CodePointBreakIterator& operator=(const CodePointBreakIterator& that);
+
+ 		virtual ~CodePointBreakIterator();
+
++#if U_ICU_VERSION_MAJOR_NUM >= 70
++		virtual bool operator==(const BreakIterator& that) const;
++#else
+ 		virtual UBool operator==(const BreakIterator& that) const;
++#endif
+
+ 		virtual CodePointBreakIterator* clone(void) const;
+
+ 		virtual UClassID getDynamicClassID(void) const;
+
+ 		virtual CharacterIterator& getText(void) const;
+
+ 		virtual UText *getUText(UText *fillIn, UErrorCode &status) const;
+
+ 		virtual void setText(const UnicodeString &text);

--- a/Patches/php72-icu70.patch
+++ b/Patches/php72-icu70.patch
@@ -1,0 +1,129 @@
+diff --git a/ext/intl/breakiterator/codepointiterator_internal.cpp b/ext/intl/breakiterator/codepointiterator_internal.cpp
+index 723cfd5022..f6f75d2731 100644
+--- a/ext/intl/breakiterator/codepointiterator_internal.cpp
++++ b/ext/intl/breakiterator/codepointiterator_internal.cpp
+@@ -74,7 +74,11 @@ CodePointBreakIterator::~CodePointBreakIterator()
+ 	clearCurrentCharIter();
+ }
+ 
++#if U_ICU_VERSION_MAJOR_NUM >= 70
++bool CodePointBreakIterator::operator==(const BreakIterator& that) const
++#else
+ UBool CodePointBreakIterator::operator==(const BreakIterator& that) const
++#endif
+ {
+ 	if (typeid(*this) != typeid(that)) {
+ 		return FALSE;
+diff --git a/ext/intl/breakiterator/codepointiterator_internal.h b/ext/intl/breakiterator/codepointiterator_internal.h
+index d34fc0a2c2..25759c167a 100644
+--- a/ext/intl/breakiterator/codepointiterator_internal.h
++++ b/ext/intl/breakiterator/codepointiterator_internal.h
+@@ -36,7 +36,11 @@ namespace PHP {
+ 
+ 		virtual ~CodePointBreakIterator();
+ 
++#if U_ICU_VERSION_MAJOR_NUM >= 70
++		virtual bool operator==(const BreakIterator& that) const;
++#else
+ 		virtual UBool operator==(const BreakIterator& that) const;
++#endif
+ 
+ 		virtual CodePointBreakIterator* clone(void) const;
+ 
+diff --git a/ext/intl/locale/locale_methods.c b/ext/intl/locale/locale_methods.c
+index 3379916822..4fb0bfcaa5 100644
+--- a/ext/intl/locale/locale_methods.c
++++ b/ext/intl/locale/locale_methods.c
+@@ -1333,7 +1333,7 @@ PHP_FUNCTION(locale_filter_matches)
+ 		if( token && (token==cur_lang_tag) ){
+ 			/* check if the char. after match is SEPARATOR */
+ 			chrcheck = token + (strlen(cur_loc_range));
+-			if( isIDSeparator(*chrcheck) || isEndOfTag(*chrcheck) ){
++			if( isIDSeparator(*chrcheck) || isKeywordSeparator(*chrcheck) || isEndOfTag(*chrcheck) ){
+ 				if( cur_lang_tag){
+ 					efree( cur_lang_tag );
+ 				}
+@@ -1389,7 +1389,7 @@ PHP_FUNCTION(locale_filter_matches)
+ 		if( token && (token==cur_lang_tag) ){
+ 			/* check if the char. after match is SEPARATOR */
+ 			chrcheck = token + (strlen(cur_loc_range));
+-			if( isIDSeparator(*chrcheck) || isEndOfTag(*chrcheck) ){
++			if( isIDSeparator(*chrcheck) || isKeywordSeparator(*chrcheck) || isEndOfTag(*chrcheck) ){
+ 				if( cur_lang_tag){
+ 					efree( cur_lang_tag );
+ 				}
+diff --git a/ext/intl/tests/dateformat_get_set_calendar_variant5.phpt b/ext/intl/tests/dateformat_get_set_calendar_variant5.phpt
+index 43e9a8516b..6f828b0305 100644
+--- a/ext/intl/tests/dateformat_get_set_calendar_variant5.phpt
++++ b/ext/intl/tests/dateformat_get_set_calendar_variant5.phpt
+@@ -1,9 +1,9 @@
+ --TEST--
+-IntlDateFormatter: setCalendar()/getCalendar()/getCalendarObject()
++IntlDateFormatter: setCalendar()/getCalendar()/getCalendarObject() for ICU >= 58.1 and < 70.1
+ --SKIPIF--
+ <?php
+ if (!extension_loaded('intl')) die('skip intl extension not enabled'); ?>
+-<?php if (version_compare(INTL_ICU_VERSION, '58.1') < 0) die('skip for ICU >= 58.1'); ?>
++<?php if (version_compare(INTL_ICU_VERSION, '58.1') < 0 || version_compare(INTL_ICU_VERSION, '70.1') >= 0) die('skip for ICU >= 58.1 and < 70.1'); ?>
+ --FILE--
+ <?php
+ ini_set("intl.error_level", E_WARNING);
+diff --git a/ext/intl/tests/dateformat_get_set_calendar_variant5_icu70.phpt b/ext/intl/tests/dateformat_get_set_calendar_variant5_icu70.phpt
+new file mode 100644
+index 0000000000..fcea014497
+--- /dev/null
++++ b/ext/intl/tests/dateformat_get_set_calendar_variant5_icu70.phpt
+@@ -0,0 +1,53 @@
++--TEST--
++IntlDateFormatter: setCalendar()/getCalendar()/getCalendarObject() for ICU >= 70.1
++--EXTENSIONS--
++intl
++--SKIPIF--
++<?php if (version_compare(INTL_ICU_VERSION, '70.1') < 0) die('skip for ICU >= 70.1'); ?>
++--FILE--
++<?php
++ini_set("intl.error_level", E_WARNING);
++ini_set("intl.default_locale", "pt_PT");
++ini_set("date.timezone", 'Atlantic/Azores');
++
++$ts = strtotime('2012-01-01 00:00:00 UTC');
++
++function d(IntlDateFormatter $df) {
++global $ts;
++echo $df->format($ts), "\n";
++var_dump($df->getCalendar(),
++$df->getCalendarObject()->getType(),
++$df->getCalendarObject()->getTimeZone()->getId());
++echo "\n";
++}
++
++$df = new IntlDateFormatter('fr@calendar=islamic', 0, 0, 'Europe/Minsk');
++d($df);
++
++
++//changing the calendar with a cal type should not change tz
++$df->setCalendar(IntlDateFormatter::TRADITIONAL);
++d($df);
++
++//but changing with an actual calendar should
++$cal = IntlCalendar::createInstance("UTC");
++$df->setCalendar($cal);
++d($df);
++
++?>
++--EXPECT--
++dimanche 1 janvier 2012 ap. J.-C. à 03:00:00 heure de Kaliningrad
++int(1)
++string(9) "gregorian"
++string(12) "Europe/Minsk"
++
++dimanche 8 safar 1433 AH à 03:00:00 heure de Kaliningrad
++int(0)
++string(7) "islamic"
++string(12) "Europe/Minsk"
++
++dimanche 1 janvier 2012 ap. J.-C. à 00:00:00 temps universel coordonné
++bool(false)
++string(9) "gregorian"
++string(3) "UTC"
++

--- a/Patches/php73-icu70.patch
+++ b/Patches/php73-icu70.patch
@@ -1,0 +1,129 @@
+diff --git a/ext/intl/breakiterator/codepointiterator_internal.cpp b/ext/intl/breakiterator/codepointiterator_internal.cpp
+index 723cfd5022..f6f75d2731 100644
+--- a/ext/intl/breakiterator/codepointiterator_internal.cpp
++++ b/ext/intl/breakiterator/codepointiterator_internal.cpp
+@@ -74,7 +74,11 @@ CodePointBreakIterator::~CodePointBreakIterator()
+ 	clearCurrentCharIter();
+ }
+ 
++#if U_ICU_VERSION_MAJOR_NUM >= 70
++bool CodePointBreakIterator::operator==(const BreakIterator& that) const
++#else
+ UBool CodePointBreakIterator::operator==(const BreakIterator& that) const
++#endif
+ {
+ 	if (typeid(*this) != typeid(that)) {
+ 		return FALSE;
+diff --git a/ext/intl/breakiterator/codepointiterator_internal.h b/ext/intl/breakiterator/codepointiterator_internal.h
+index d34fc0a2c2..25759c167a 100644
+--- a/ext/intl/breakiterator/codepointiterator_internal.h
++++ b/ext/intl/breakiterator/codepointiterator_internal.h
+@@ -36,7 +36,11 @@ namespace PHP {
+ 
+ 		virtual ~CodePointBreakIterator();
+ 
++#if U_ICU_VERSION_MAJOR_NUM >= 70
++		virtual bool operator==(const BreakIterator& that) const;
++#else
+ 		virtual UBool operator==(const BreakIterator& that) const;
++#endif
+ 
+ 		virtual CodePointBreakIterator* clone(void) const;
+ 
+diff --git a/ext/intl/locale/locale_methods.c b/ext/intl/locale/locale_methods.c
+index 3379916822..4fb0bfcaa5 100644
+--- a/ext/intl/locale/locale_methods.c
++++ b/ext/intl/locale/locale_methods.c
+@@ -1326,7 +1326,7 @@ PHP_FUNCTION(locale_filter_matches)
+ 		if( token && (token==cur_lang_tag) ){
+ 			/* check if the char. after match is SEPARATOR */
+ 			chrcheck = token + (strlen(cur_loc_range));
+-			if( isIDSeparator(*chrcheck) || isEndOfTag(*chrcheck) ){
++			if( isIDSeparator(*chrcheck) || isKeywordSeparator(*chrcheck) || isEndOfTag(*chrcheck) ){
+ 				efree( cur_lang_tag );
+ 				efree( cur_loc_range );
+ 				if( can_lang_tag){
+@@ -1378,7 +1378,7 @@ PHP_FUNCTION(locale_filter_matches)
+ 		if( token && (token==cur_lang_tag) ){
+ 			/* check if the char. after match is SEPARATOR */
+ 			chrcheck = token + (strlen(cur_loc_range));
+-			if( isIDSeparator(*chrcheck) || isEndOfTag(*chrcheck) ){
++			if( isIDSeparator(*chrcheck) || isKeywordSeparator(*chrcheck) || isEndOfTag(*chrcheck) ){
+ 				efree( cur_lang_tag );
+ 				efree( cur_loc_range );
+ 				RETURN_TRUE;
+diff --git a/ext/intl/tests/dateformat_get_set_calendar_variant5.phpt b/ext/intl/tests/dateformat_get_set_calendar_variant5.phpt
+index 43e9a8516b..6f828b0305 100644
+--- a/ext/intl/tests/dateformat_get_set_calendar_variant5.phpt
++++ b/ext/intl/tests/dateformat_get_set_calendar_variant5.phpt
+@@ -1,9 +1,9 @@
+ --TEST--
+-IntlDateFormatter: setCalendar()/getCalendar()/getCalendarObject()
++IntlDateFormatter: setCalendar()/getCalendar()/getCalendarObject() for ICU >= 58.1 and < 70.1
+ --SKIPIF--
+ <?php
+ if (!extension_loaded('intl')) die('skip intl extension not enabled'); ?>
+-<?php if (version_compare(INTL_ICU_VERSION, '58.1') < 0) die('skip for ICU >= 58.1'); ?>
++<?php if (version_compare(INTL_ICU_VERSION, '58.1') < 0 || version_compare(INTL_ICU_VERSION, '70.1') >= 0) die('skip for ICU >= 58.1 and < 70.1'); ?>
+ --FILE--
+ <?php
+ ini_set("intl.error_level", E_WARNING);
+diff --git a/ext/intl/tests/dateformat_get_set_calendar_variant5_icu70.phpt b/ext/intl/tests/dateformat_get_set_calendar_variant5_icu70.phpt
+new file mode 100644
+index 0000000000..fcea014497
+--- /dev/null
++++ b/ext/intl/tests/dateformat_get_set_calendar_variant5_icu70.phpt
+@@ -0,0 +1,53 @@
++--TEST--
++IntlDateFormatter: setCalendar()/getCalendar()/getCalendarObject() for ICU >= 70.1
++--EXTENSIONS--
++intl
++--SKIPIF--
++<?php if (version_compare(INTL_ICU_VERSION, '70.1') < 0) die('skip for ICU >= 70.1'); ?>
++--FILE--
++<?php
++ini_set("intl.error_level", E_WARNING);
++ini_set("intl.default_locale", "pt_PT");
++ini_set("date.timezone", 'Atlantic/Azores');
++
++$ts = strtotime('2012-01-01 00:00:00 UTC');
++
++function d(IntlDateFormatter $df) {
++global $ts;
++echo $df->format($ts), "\n";
++var_dump($df->getCalendar(),
++$df->getCalendarObject()->getType(),
++$df->getCalendarObject()->getTimeZone()->getId());
++echo "\n";
++}
++
++$df = new IntlDateFormatter('fr@calendar=islamic', 0, 0, 'Europe/Minsk');
++d($df);
++
++
++//changing the calendar with a cal type should not change tz
++$df->setCalendar(IntlDateFormatter::TRADITIONAL);
++d($df);
++
++//but changing with an actual calendar should
++$cal = IntlCalendar::createInstance("UTC");
++$df->setCalendar($cal);
++d($df);
++
++?>
++--EXPECT--
++dimanche 1 janvier 2012 ap. J.-C. à 03:00:00 heure de Kaliningrad
++int(1)
++string(9) "gregorian"
++string(12) "Europe/Minsk"
++
++dimanche 8 safar 1433 AH à 03:00:00 heure de Kaliningrad
++int(0)
++string(7) "islamic"
++string(12) "Europe/Minsk"
++
++dimanche 1 janvier 2012 ap. J.-C. à 00:00:00 temps universel coordonné
++bool(false)
++string(9) "gregorian"
++string(3) "UTC"
++


### PR DESCRIPTION
Fix the installation of older versions of PHP due to the update of ICU 70

Fixed issues: https://github.com/henkrehorst/homebrew-php/issues/158

More info: https://github.com/php/php-src/pull/7596

Thanks [@nickolasburr](https://github.com/nickolasburr) for the hint!
