### PR TITLE
Update valet-php@7.4.rb

### DIFF
--- a/Formula/valet-php@7.4.rb
+++ b/Formula/valet-php@7.4.rb
@@ -291,7 +291,7 @@ class ValetPhpAT74 < Formula
     version.to_s.split(".")[0..1].join(".")
   end
 
-  plist_options manual: "php-fpm"
+  service.require_root manual: "php-fpm"
 
   def plist
     <<~EOS


### PR DESCRIPTION
Calling plist_options is deprecated. Using service.require_root instead.